### PR TITLE
Use GHA to publish releases.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,14 @@ jobs:
 
       - name: Build
         run: npm run build
+
+     - name: Package
+       run: npm pack
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: openequella-react-kaltura-simpleuploader-*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Build
         run: npm run build
 
-     - name: Package
-       run: npm pack
+      - name: Package
+        run: npm pack
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Use GHA to publish releases, including two steps:
1. run `npm pack` to generate a package.
2. use GHA to publish, which is triggered by a new tag.