### PR TITLE
chore: add the Kaltura Client to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "kaltura-typescript-client-7.0.2-v20210602-152238.tgz"
   ],
   "config": {
     "lintglobs": "src/**/*.{ts,tsx} test/**/*.{ts,tsx} stories/**/*.{ts,tsx}"


### PR DESCRIPTION
We need to include the Kaltura Client zip file in the package so that in the Kaltura Plugin side we can install this component.

![image](https://user-images.githubusercontent.com/47203811/122005148-9debec80-cdf8-11eb-8ca6-c1c5d2a17e9a.png)
