### PR TITLE
Feat/add callback for upload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:jest/recommended",
     "plugin:jest/style",
     "plugin:prettier/recommended",
@@ -19,7 +18,6 @@
       "jsx": true
     },
     "ecmaVersion": 12,
-    "project": ["./tsconfig.json"],
     "sourceType": "module"
   },
   "plugins": ["react", "@typescript-eslint"],

--- a/example/index.js
+++ b/example/index.js
@@ -1,9 +1,16 @@
 import { render, kalturaSaasEndpoint } from "../dist";
 import config from "./config";
 
+const callback = (entries) => {
+  console.log("Callback was called with the following entries:");
+  console.log(entries);
+  document.getElementById("root").textContent = "Process complete, see console log!";
+};
+
 render(
   document.getElementById("root"),
   kalturaSaasEndpoint,
   config.ks,
-  config.partnerId
+  config.partnerId,
+  callback
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openequella/react-kaltura-simpleuploader",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15707,8 +15707,8 @@
       "dev": true
     },
     "kaltura-typescript-client": {
-      "version": "file:kaltura-typescript-client-7.0.2-v20210602-152238.tgz",
-      "integrity": "sha512-Zmqb6q5wT0/MgN1yJJpzs+zZYhaHhGOGuOIJoYO4WLniFzuqUf6Fe8kdP8AJbp6T5rFbU/NTN2XXMKopnpT8Mg=="
+      "version": "https://github.com/openequella/kaltura-typescript-client/releases/download/v17.2.0/kaltura-typescript-client-7.0.2-v20210618-014917.tgz",
+      "integrity": "sha512-ivIPTdrDhO9f8Fmb5IMaCkBNC+Iv97kXVwxHa/+Pa3ITfALd5PZd+atPraOrGsiGHovNeTbTJYgvSGScxxEL0A=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6696,6 +6696,16 @@
         }
       }
     },
+    "babel-plugin-import": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.13.3.tgz",
+      "integrity": "sha512-1qCWdljJOrDRH/ybaCZuDgySii4yYrtQ8OJQwrcDqdt0y67N30ng3X3nABg6j7gR7qUJgcMa9OMhc4AGViDwWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "kaltura-typescript-client-7.0.2-v20210602-152238.tgz"
+    "src"
   ],
   "config": {
     "lintglobs": "src/**/*.{ts,tsx} test/**/*.{ts,tsx} stories/**/*.{ts,tsx}"
@@ -57,7 +56,7 @@
     "typescript": "4.3.2"
   },
   "dependencies": {
-    "kaltura-typescript-client": "file:kaltura-typescript-client-7.0.2-v20210602-152238.tgz",
+    "kaltura-typescript-client": "https://github.com/openequella/kaltura-typescript-client/releases/download/v17.2.0/kaltura-typescript-client-7.0.2-v20210618-014917.tgz",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.14.6",
+    "babel-plugin-import": "1.13.3",
     "@commitlint/cli": "12.1.4",
     "@commitlint/config-conventional": "12.1.4",
     "@storybook/addon-actions": "6.2.9",
@@ -64,5 +65,18 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix"
+  },
+  "babel": {
+    "plugins": [
+      [
+        "import",
+        {
+          "libraryName": "kaltura-typescript-client/api/types",
+          "libraryDirectory": "",
+          "camel2DashComponentName": false,
+          "transformToDefaultImport": false
+        }
+      ]
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,4 +18,5 @@ export default {
     },
   ],
   plugins: [typescript()],
+  external: [ "react", "react-dom", "react-error-boundary", "kaltura-typescript-client", "kaltura-typescript-client/api/types", "lodash" ]
 };

--- a/src/KalturaUploader.tsx
+++ b/src/KalturaUploader.tsx
@@ -110,7 +110,7 @@ const KalturaUploaderInternal = ({
     if (state.id === "complete") {
       callback([state.entry]);
     }
-  }, [state.id, callback]);
+  }, [state, callback]);
 
   const client = createClient(endpoint, ks, partnerId);
 

--- a/src/KalturaUploader.tsx
+++ b/src/KalturaUploader.tsx
@@ -8,7 +8,7 @@ import { createClient } from "KalturaModule";
 import { reducer } from "KalturaUploaderReducer";
 import { Metadata } from "Metadata";
 import * as React from "react";
-import { useReducer, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { withErrorBoundary } from "react-error-boundary";
 import { Upload } from "Upload";
 
@@ -84,6 +84,11 @@ export interface KalturaUploaderProps {
    * A Kaltura partner ID.
    */
   partnerId: number;
+  /**
+   * Callback to call when an upload is completed.
+   * @param entries A list of KalturaMediaEntry.
+   */
+  callback: (entries: KalturaMediaEntry[]) => void;
 }
 
 /**
@@ -94,11 +99,18 @@ const KalturaUploaderInternal = ({
   endpoint,
   ks,
   partnerId,
+  callback,
 }: KalturaUploaderProps): JSX.Element => {
   const [state, dispatch] = useReducer(reducer, { id: "start" });
   const [mediaType, setMediaType] = useState<MediaTypeOptions>(
     MediaTypes.video
   );
+
+  useEffect(() => {
+    if (state.id === "complete") {
+      callback([state.entry]);
+    }
+  }, [state.id, callback]);
 
   const client = createClient(endpoint, ks, partnerId);
 
@@ -153,21 +165,6 @@ const KalturaUploaderInternal = ({
           }
           uploadResult={state.uploadResult}
         />
-      )}
-      {state.id === "complete" && (
-        <>
-          <h2>New Media Entry created.</h2>
-          <p>
-            <strong>{state.entry.name}</strong>
-          </p>
-          <p>{state.entry.description}</p>
-          <a target="_blank" href={state.entry.dataUrl} rel="noreferrer">
-            <img src={state.entry.thumbnailUrl} alt="Thumbnail" />
-          </a>
-          <p>
-            <a href={state.entry.downloadUrl}>Download Video.</a>
-          </p>
-        </>
       )}
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { KalturaUploader } from "KalturaUploader";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import { KalturaMediaEntry } from "kaltura-typescript-client/api/types";
 
 /**
  * Convenience constant pointing at common endpoint for using Kaltura SaaS platform.
@@ -10,23 +11,22 @@ export const kalturaSaasEndpoint = "https://www.kaltura.com/";
 /**
  * Renders the Kaltura Simple Uploader component to the specified DOM element.
  *
- * TODO: Add a method to return a link to the new Kaltura entry - maybe a callback. Need to confirm
- *       what the openEQUELLA Kaltura plugin is expecting.
- *
  * @param targetElem The element to render the component to - typically a `<div>`
  * @param endpoint The endpoint for the Kaltura server to use. (For Kaltura SaaS simply use
  *                 `kalturaSaasEndpoint`.
  * @param ks A Kaltura session token
  * @param partnerId The partner ID matching the provided `ks`
+ * @param callback Callback to call when an upload is completed. Typically, this is provided by openEQUELLA Kaltura plugin.
  */
 export const render = (
   targetElem: HTMLElement,
   endpoint: string,
   ks: string,
-  partnerId: number
+  partnerId: number,
+  callback: (entries: KalturaMediaEntry[]) => void
 ): void => {
   ReactDOM.render(
-    <KalturaUploader {...{ endpoint, ks, partnerId }} />,
+    <KalturaUploader {...{ endpoint, ks, partnerId, callback }} />,
     targetElem
   );
 };

--- a/test/KalturaUploader.test.tsx
+++ b/test/KalturaUploader.test.tsx
@@ -9,6 +9,7 @@ describe("<KalturaUploader/>", () => {
         endpoint="https://www.kaltura.com/"
         ks="not-a-real-key"
         partnerId={1234}
+        callback={jest.fn()}
       />
     );
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -4,7 +4,7 @@ import { kalturaUploaderId } from "../src/KalturaUploader";
 describe("Exported render function", () => {
   it("correctly renders the component", () => {
     const targetElem = document.createElement("div");
-    render(targetElem, kalturaSaasEndpoint, "not-a-real-ks", 1234);
+    render(targetElem, kalturaSaasEndpoint, "not-a-real-ks", 1234, jest.fn());
     expect(targetElem.querySelector(`#${kalturaUploaderId}`)).toBeTruthy();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "test", "stories"],
+  "include": ["src"],
   "compilerOptions": {
     "module": "ES6",
     "lib": ["es2020", "dom"],


### PR DESCRIPTION
This PR's focus is adding the support of calling a callback when an upload is completed. However, there are more commits included to resolve warnings and configuration issues. They are: 

1. Using URL rather than local package to install the Kaltura TS Client API;
2. Not generating type definition files for tests and storybooks;
3. Removing the use of `@typescript-eslint/recommended-requiring-type-checking`;
4. Resolving Rollup build warnings about `unresolved dependencies`;
5. Resolving warnings about bundling the whole Kaltura TS Client API (not perfectly addressed as you still can see the warning in test)

All npm tasks are passed after above changes.